### PR TITLE
Fix: generate optional interface methods with name suffix "?"

### DIFF
--- a/packages/dts-generator/lib/ast.d.ts
+++ b/packages/dts-generator/lib/ast.d.ts
@@ -35,6 +35,7 @@ interface FunctionDesc extends UI5JSDocs {
   // descriptions of potential errors being throws
   throws?: { type?: string; description: string }[];
   visibility: UI5Visibility;
+  optional: boolean;
 }
 
 interface Property extends UI5JSDocs {

--- a/packages/dts-generator/lib/phases/dts-code-gen.js
+++ b/packages/dts-generator/lib/phases/dts-code-gen.js
@@ -230,7 +230,8 @@ function genMethodOrFunction(ast, staticPossible, isFunc) {
   text += JSDOC(ast) + NL;
   text += ast.overwrite ? "// @ts-ignore" + NL : "";
   text += ast.static && staticPossible ? "static " : "";
-  text += `${isFunc ? "function " : ""}${ast.name} (` + NL;
+  text +=
+    `${isFunc ? "function " : ""}${ast.name}${ast.optional ? "?" : ""} (` + NL;
   text += APPEND_ITEMS(ast.parameters, genParameter, { sep: COMMA });
 
   text += ")";

--- a/packages/dts-generator/lib/phases/json-to-ast.js
+++ b/packages/dts-generator/lib/phases/json-to-ast.js
@@ -118,7 +118,8 @@ function buildFunction(ui5Method) {
     since: ui5Method.since,
     throws: ui5Method.throws ? ui5Method.throws : [],
     deprecated: buildDeprecated(ui5Method.deprecated),
-    visibility: ui5Method.visibility
+    visibility: ui5Method.visibility,
+    optional: ui5Method.optional
   };
 
   addJsDocProps(astNode, ui5Method);


### PR DESCRIPTION
UI5 api.json meanwhile allows to mark interface methods as optional.
dts-generator can use this information to marke the method as optional
in the TS interface, too.

Fixes #43.