### PR TITLE
feat: export replacement interfaces for module declaration

### DIFF
--- a/packages/dts-generator/lib/phases/ast-fixer.js
+++ b/packages/dts-generator/lib/phases/ast-fixer.js
@@ -273,6 +273,7 @@ function fixNamespacesAsInterfaces(
         name: nestedNs.name,
         methods: nestedNs.functions,
         parent: currNS,
+        namespace: true,
       };
     });
 

--- a/packages/dts-generator/lib/phases/ast-fixer.js
+++ b/packages/dts-generator/lib/phases/ast-fixer.js
@@ -273,7 +273,9 @@ function fixNamespacesAsInterfaces(
         name: nestedNs.name,
         methods: nestedNs.functions,
         parent: currNS,
-        namespace: true,
+        // indicator to remember that this interface
+        // has been created from a namespace originally
+        isNamespace: true,
       };
     });
 

--- a/packages/dts-generator/lib/phases/dts-code-gen.js
+++ b/packages/dts-generator/lib/phases/dts-code-gen.js
@@ -183,6 +183,9 @@ function genInterface(ast) {
   text += APPEND_ITEMS(ast.methods, genInstanceMethod);
 
   text += "}";
+  if (ast.namespace) {
+    text += NL + `export const ${ast.name}: ${ast.name};`;
+  }
   return text;
 }
 

--- a/packages/dts-generator/lib/phases/dts-code-gen.js
+++ b/packages/dts-generator/lib/phases/dts-code-gen.js
@@ -183,7 +183,25 @@ function genInterface(ast) {
   text += APPEND_ITEMS(ast.methods, genInstanceMethod);
 
   text += "}";
-  if (ast.namespace) {
+  /*
+   * In order to export namespaces converted to interfaces as
+   * modules we need to assign those mapped interfaces to const
+   *
+   * The following snippet shows how such an interface needs
+   * to be defined to re-export it as module:
+   *
+   *   interface BusyIndicator {
+   *     [...]
+   *   }
+   *   export const BusyIndicator: BusyIndicator;
+   *
+   * The following snippet shows how the re-export as module
+   * can be done:
+   *
+   *   declare module "sap/ui/core/BusyIndicator" { export default sap.ui.core.BusyIndicator; }
+   *
+   */
+  if (ast.isNamespace) {
     text += NL + `export const ${ast.name}: ${ast.name};`;
   }
   return text;

--- a/packages/dts-generator/types/ast.d.ts
+++ b/packages/dts-generator/types/ast.d.ts
@@ -87,6 +87,7 @@ interface Interface extends UI5JSDocs {
   methods: FunctionDesc[];
   props: Property[];
   visibility: UI5Visibility;
+  isNamespace?: boolean;
 }
 
 interface DeprecatedDesc {

--- a/test-packages/openui5-snapshot-test/output-dts/sap.f.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.f.d.ts
@@ -6174,6 +6174,7 @@ declare namespace sap {
     }
 
     interface DynamicPageTitleShrinkRatio {}
+    export const DynamicPageTitleShrinkRatio: DynamicPageTitleShrinkRatio;
     /**
      * @SINCE 1.46
      * @deprecated (since 1.73) - Use the {@link sap.m.Avatar} instead.

--- a/test-packages/openui5-snapshot-test/output-dts/sap.m.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.m.d.ts
@@ -21974,8 +21974,10 @@ declare namespace sap {
         oPopover: sap.ui.core.Control
       ): sap.ui.core.Control;
     }
+    export const InstanceManager: InstanceManager;
 
     interface touch {}
+    export const touch: touch;
 
     interface URLHelper {
       /**
@@ -22110,8 +22112,10 @@ declare namespace sap {
         sTel?: string
       ): void;
     }
+    export const URLHelper: URLHelper;
 
     interface ValueCSSColor {}
+    export const ValueCSSColor: ValueCSSColor;
     /**
      * The `sap.m.ActionListItem` can be used like a `button` to fire actions when pressed. **Note:** The inherited
      * `selected` property of the `sap.m.ListItemBase` is not supported.

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
@@ -15148,8 +15148,10 @@ declare namespace sap {
             }
           ): Promise<any>;
         }
+        export const RuleEngineOpaAssertions: RuleEngineOpaAssertions;
 
         interface usage {}
+        export const usage: usage;
         /**
          * @SINCE 1.48
          *
@@ -16362,6 +16364,7 @@ declare namespace sap {
 
         namespace serializer {
           interface delegate {}
+          export const delegate: delegate;
         }
 
         interface $ExportSettings extends sap.ui.core.$ControlSettings {
@@ -16391,6 +16394,7 @@ declare namespace sap {
         }
 
         interface reflection {}
+        export const reflection: reflection;
         /**
          * @SINCE 1.22.0
          * @deprecated (since 1.73)
@@ -18699,6 +18703,7 @@ declare namespace sap {
       }
 
       interface AbsoluteCSSSize {}
+      export const AbsoluteCSSSize: AbsoluteCSSSize;
 
       interface BusyIndicator {
         /**
@@ -18777,30 +18782,43 @@ declare namespace sap {
           iDelay?: number
         ): void;
       }
+      export const BusyIndicator: BusyIndicator;
 
       interface BusyIndicatorUtils {}
+      export const BusyIndicatorUtils: BusyIndicatorUtils;
 
       interface Collision {}
+      export const Collision: Collision;
 
       interface CSSColor {}
+      export const CSSColor: CSSColor;
 
       interface CSSSize {}
+      export const CSSSize: CSSSize;
 
       interface CSSSizeShortHand {}
+      export const CSSSizeShortHand: CSSSizeShortHand;
 
       interface Dock {}
+      export const Dock: Dock;
 
       interface ID {}
+      export const ID: ID;
 
       interface Percentage {}
+      export const Percentage: Percentage;
 
       interface URI {}
+      export const URI: URI;
 
       interface date {}
+      export const date: date;
 
       interface postmessage {}
+      export const postmessage: postmessage;
 
       interface service {}
+      export const service: service;
       /**
        * @SINCE 1.70
        */

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.layout.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.layout.d.ts
@@ -164,10 +164,13 @@ declare namespace sap {
         }
 
         interface CSSGridGapShortHand {}
+        export const CSSGridGapShortHand: CSSGridGapShortHand;
 
         interface CSSGridLine {}
+        export const CSSGridLine: CSSGridLine;
 
         interface CSSGridTrack {}
+        export const CSSGridTrack: CSSGridTrack;
         /**
          * @SINCE 1.60
          *
@@ -2918,16 +2921,22 @@ declare namespace sap {
         }
 
         interface ColumnCells {}
+        export const ColumnCells: ColumnCells;
 
         interface ColumnsL {}
+        export const ColumnsL: ColumnsL;
 
         interface ColumnsM {}
+        export const ColumnsM: ColumnsM;
 
         interface ColumnsXL {}
+        export const ColumnsXL: ColumnsXL;
 
         interface EmptyCells {}
+        export const EmptyCells: EmptyCells;
 
         interface GridElementCells {}
+        export const GridElementCells: GridElementCells;
         /**
          * @SINCE 1.56.0
          *
@@ -6928,10 +6937,13 @@ declare namespace sap {
       }
 
       interface BoxesPerRowConfig {}
+      export const BoxesPerRowConfig: BoxesPerRowConfig;
 
       interface GridIndent {}
+      export const GridIndent: GridIndent;
 
       interface GridSpan {}
+      export const GridSpan: GridSpan;
       /**
        * @SINCE 1.34
        *


### PR DESCRIPTION
To allow static namespaces to be imported as ES module, the
replacement interfaces need to be exported as const, e.g.:

```js
interface BusyIndicator {}
export const BusyIndicator: BusyIndicator;

declare module "BusyIndicator" { export default BusyIndicator; }
```