### PR TITLE
feat: add dependenciesTypePackagesForCheck option

### DIFF
--- a/packages/dts-generator/api-report/dts-generator.api.md
+++ b/packages/dts-generator/api-report/dts-generator.api.md
@@ -57,7 +57,7 @@ export interface Directives {
 }
 
 // @public
-export function generate({ apiFile, dependencyApiFiles, directiveFiles, targetFile, dependencyDTSFilesForCheck, generateGlobals, runCheckCompile, errorOutputFile, }: GenerateConfig): Promise<boolean>;
+export function generate({ apiFile, dependencyApiFiles, directiveFiles, targetFile, dependencyDTSFilesForCheck, dependenciesTypePackagesForCheck, generateGlobals, runCheckCompile, errorOutputFile, }: GenerateConfig): Promise<boolean>;
 
 // @public
 export type GenerateConfig = {
@@ -66,6 +66,7 @@ export type GenerateConfig = {
     directiveFiles: string[];
     targetFile: string;
     dependencyDTSFilesForCheck: string[];
+    dependenciesTypePackagesForCheck?: string[];
     generateGlobals?: boolean;
     runCheckCompile?: boolean;
     errorOutputFile?: string;
@@ -93,6 +94,7 @@ export interface GenerateFromPathsConfig {
     apiFile: string;
     dependenciesApiPath: string;
     dependenciesDTSPathForCheck: string;
+    dependenciesTypePackagesForCheck?: string;
     directivesPath: string;
     generateGlobals?: boolean;
     runCheckCompile?: boolean;

--- a/packages/dts-generator/src/generate-from-paths.ts
+++ b/packages/dts-generator/src/generate-from-paths.ts
@@ -45,9 +45,28 @@ export interface GenerateFromPathsConfig {
   directivesPath: string;
 
   /**
-   * Directory where the d.ts files are located of the libraries on which the currently to-be-built library depends. Only needed for the check.
+   * Directory where the d.ts files are located of the libraries on which the currently to-be-built library depends.
+   *
+   * This is meant for other libraries which belong to the same project and are built in the same build run, as opposed to external
+   * libraries. E.g. when the OpenUI5 types are built, then the core library is built first and its resulting d.ts file is a dependency
+   * for building the types of other libraries like sap.m.
+   *
+   * Only needed for the check.
    */
   dependenciesDTSPathForCheck: string;
+
+  /**
+   * Comma-separated list of package names of the libraries on which the currently to-be-built types depends.
+   *
+   * This is meant for entire npm packages developed separately (often by others), not sibling libraries built in the same batch.
+   * E.g. when a custom UI5 control library is built by an application team, then it usually depends on the OpenUI5 types because
+   * those define the base classes like Control.
+   * Setting this has the effect that for the TS compilation check, the `types` field of the package.json file will be set to the
+   * respective package names and any other type packages are no longer considered.
+   *
+   * Only needed for the check.
+   */
+  dependenciesTypePackagesForCheck?: string;
 
   /**
    * File path and name of the target d.ts file to write.
@@ -92,8 +111,11 @@ export async function generateFromPaths(config: GenerateFromPathsConfig) {
     targetFile: config.targetFile,
     dependencyDTSFilesForCheck: await findFiles(
       config.dependenciesDTSPathForCheck,
-      "-d.ts",
+      "d.ts",
     ),
+    dependenciesTypePackagesForCheck: config.dependenciesTypePackagesForCheck
+      ? config.dependenciesTypePackagesForCheck.split(",")
+      : [],
     runCheckCompile: config.runCheckCompile,
   });
   return success;

--- a/packages/dts-generator/src/index.ts
+++ b/packages/dts-generator/src/index.ts
@@ -39,6 +39,7 @@ async function main() {
     dependenciesApiPath,
     dependenciesDTSPathForCheckForGlobals,
     dependenciesDTSPathForCheck,
+    dependenciesTypePackagesForCheck,
     directivesPath,
     targetFileForGlobals,
     targetFile,
@@ -60,6 +61,11 @@ async function main() {
       dependenciesDTSPathForCheck || "(none)"
     }`,
   );
+  log.info(
+    `  dependency type packages: ${
+      dependenciesTypePackagesForCheck || "(none)"
+    }`,
+  );
   log.info(`  target file for globals: ${targetFileForGlobals}`);
   log.info(`  target file for modules: ${targetFile}`);
   log.info(`  verbose: ${verbose}`);
@@ -78,6 +84,7 @@ async function main() {
       dependenciesApiPath,
       directivesPath,
       dependenciesDTSPathForCheck: dependenciesDTSPathForCheckForGlobals,
+      dependenciesTypePackagesForCheck,
       targetFile: targetFileForGlobals,
       runCheckCompile,
       verbose,
@@ -92,6 +99,7 @@ async function main() {
       dependenciesApiPath,
       directivesPath,
       dependenciesDTSPathForCheck,
+      dependenciesTypePackagesForCheck,
       targetFile,
       runCheckCompile,
       verbose,

--- a/packages/dts-generator/src/utils/arguments-index.ts
+++ b/packages/dts-generator/src/utils/arguments-index.ts
@@ -15,6 +15,14 @@ export const args = (() => {
   parser.add_argument("--dependenciesDTSPathForCheck", {
     help: "Directory where the d.ts files are located of the libraries on which the currently to-be-built library depends. Only needed for the check.",
   });
+  parser.add_argument("--dependenciesTypePackagesForCheck", {
+    help:
+      "Comma-separated list of package names of the libraries on which the currently to-be-built types depends.  This is meant for entire npm packages" +
+      " developed separately (often by others), not sibling libraries built in the same batch. E.g. when a custom UI5 control library is built by an" +
+      " application team, then it usually depends on the OpenUI5 types because those define the base classes like Control. Setting this has the effect" +
+      " that for the TS compilation check, the `types` field of the package.json file will be set to the respective package names and any other type packages" +
+      " are no longer considered. Only needed for the check.",
+  });
   parser.add_argument("--directivesPath", {
     help: "Directory where the .dtsgenrc files for the libraries (current and dependencies) are located.",
   });


### PR DESCRIPTION
Basically this adds the "types:" option in the tsc run during the compile check.
This was not needed in the standard UI5 build environment, but when run elsewhere:

1. the OpenUI5 types need to be added as dependencies and doing this via npm package name is cleaner than pointing into the node_modules folder using the dependencyDTSFilesForCheck option and

2. tsc may automatically pick up other type packages which happen to be around and report errors or missing dependencies inside them. Setting "types" means only *these* types are considered.