### PR TITLE
introduce valueType setting for properties to support @type annotation

### DIFF
--- a/packages/dts-generator/src/types/api-json.d.ts
+++ b/packages/dts-generator/src/types/api-json.d.ts
@@ -273,6 +273,7 @@ export interface ObjProperty {
 export interface Ui5Property {
   name: Ui5SettingName;
   type?: TypeReference; // a string in the original api.json files, but parsed into an object in one of the prepare steps before json-to-ast sees it
+  valueType?: TypeReference;
   defaultValue?: any;
   group?: string;
   visibility?: "public" | "hidden" | "restricted";

--- a/packages/dts-generator/src/utils/json-constructor-settings-interfaces.ts
+++ b/packages/dts-generator/src/utils/json-constructor-settings-interfaces.ts
@@ -146,7 +146,7 @@ function createConstructorSettingsInterfaces(
           const propType = {
             kind: "UnionType",
             types: [
-              clone(prop.type),
+              clone(prop.valueType),
               {
                 kind: "TypeReference",
                 typeName: "sap.ui.base.ManagedObject.PropertyBindingInfo",
@@ -156,8 +156,8 @@ function createConstructorSettingsInterfaces(
 
           if (
             !(
-              prop.type.kind === "TypeReference" &&
-              prop.type.typeName === "string"
+              prop.valueType.kind === "TypeReference" &&
+              prop.valueType.typeName === "string"
             )
           ) {
             propType.types.push({


### PR DESCRIPTION
The runtime metadata is currently limited to basic types like `int`, `object`, `any`. For example, with Date-based controls, using `any` in TypeScript is not ideal. Typically, the preferred types are `UI5Date` or the native `Date`.

To address this, introducing the `valueType` property and use it for displaying in the API Reference.
