### PR TITLE
fix(dts-generator): fix download-apijson by querying differently

### DIFF
--- a/packages/dts-generator/src/js-utils/ui5-metadata.js
+++ b/packages/dts-generator/src/js-utils/ui5-metadata.js
@@ -61,7 +61,7 @@ export async function getSAPUI5LibsMeta(version) {
 export async function getOpenUI5PossibleLibNames() {
   const fetch = (await import("node-fetch")).default;
   const openUI5OrgResponse = await fetch(
-    `https://registry.npmjs.com/-/v1/search?text=scope:openui5&size=100`,
+    `https://registry.npmjs.com/-/v1/search?text=@openui5&size=250`,
     {
       headers: {
         "User-Agent": "@ui5-dts-generator",
@@ -74,9 +74,10 @@ export async function getOpenUI5PossibleLibNames() {
   }
   const openUI5OrgSearchText = await openUI5OrgResponse.text();
   const openUI5OrgSearch = JSON.parse(openUI5OrgSearchText);
-  const possibleOpenUI5LibNames = map(openUI5OrgSearch.objects, (_) =>
-    _.package.name.substr("@openui5/".length),
-  );
+  const possibleOpenUI5LibNames = openUI5OrgSearch.objects
+    .map((packageObject) => packageObject.package.name)
+    .filter((name) => name.startsWith("@openui5/sap"))
+    .map((name) => name.replace("@openui5/", ""));
   return possibleOpenUI5LibNames;
 }
 


### PR DESCRIPTION
Don't use the scoped search, which apparently stopped working, and use standard search instead.

The max supported limit of search results is 250 right now and the current number of hits is still lower (183). This number might increase over time to a degree where relevant libraries are not within the first 250. Results are sorted by popularity etc., so the libraries are right now still at the very beginning of the result list. This creates a comfortable buffer for the time being.

Fixes https://github.com/SAP/ui5-typescript/issues/488