### PR TITLE
feat(dts-generator): allow "esmOnly" in directives and "readonly" props

### DIFF
--- a/packages/dts-generator/api-report/dts-generator.api.md
+++ b/packages/dts-generator/api-report/dts-generator.api.md
@@ -52,7 +52,9 @@ export interface Directives {
         [orgNamespace: string]: true | [true] | [true, "keep_original_ns"];
     };
     overlays: {
-        [libraryName: string]: ConcreteSymbol[];
+        [libraryName: string]: (ConcreteSymbol & {
+            esmOnly?: boolean;
+        })[];
     };
     typeTyposMap: {
         [orgType: string]: string;

--- a/packages/dts-generator/src/generate-from-objects.ts
+++ b/packages/dts-generator/src/generate-from-objects.ts
@@ -82,7 +82,7 @@ export interface Directives {
    * mapped to TypeScript and cannot be changed in a compatible way.
    */
   overlays: {
-    [libraryName: string]: ConcreteSymbol[];
+    [libraryName: string]: (ConcreteSymbol & { esmOnly?: boolean })[];
   };
 
   /**
@@ -160,6 +160,7 @@ export async function generateFromObjects(config: GenerateFromObjectsConfig) {
     apiObject,
     actualOptions.dependencyApiObjects,
     actualOptions.directives,
+    actualOptions.generateGlobals,
   );
 
   // Phase 2 - jsonToAst:

--- a/packages/dts-generator/src/phases/dts-code-gen.ts
+++ b/packages/dts-generator/src/phases/dts-code-gen.ts
@@ -630,6 +630,7 @@ function genField(ast: Variable) {
   text += JSDOC(ast) + NL;
   text += applyTsIgnore(ast);
   text += ast.static ? "static " : "";
+  text += ast.readonly ? "readonly " : "";
   text +=
     `${ast.name} : ${ast.type ? genType(ast.type, "property") : "any"}` + NL;
   return text;

--- a/packages/dts-generator/src/phases/json-fixer.ts
+++ b/packages/dts-generator/src/phases/json-fixer.ts
@@ -931,7 +931,10 @@ export function fixApiJsons(
     const key = `${depjson.library}-${depjson.version}`;
     let preparedjson = preparedCache.get(key);
     if (!preparedjson) {
-      preparedjson = _prepareApiJson(depjson, directives);
+      preparedjson = _prepareApiJson(depjson, directives, {
+        mainLibrary: false,
+        generateGlobals,
+      });
       preparedCache.set(key, preparedjson);
     }
     return JSON.parse(JSON.stringify(preparedjson)); // cloning needed to avoid multiple processing within the subsequent steps; // TODO: but this can likely be improved

--- a/packages/dts-generator/src/phases/json-to-ast.ts
+++ b/packages/dts-generator/src/phases/json-to-ast.ts
@@ -1197,7 +1197,10 @@ const buildNestedTypedefs = _.partialRight(
  * @returns
  */
 function buildVariable(property: ObjProperty): Variable {
-  assertKnownProps(["examples", "name", "type", "value", "optional"], property);
+  assertKnownProps(
+    ["examples", "name", "type", "value", "optional", "esmOnly", "readonly"],
+    property,
+  );
 
   const astNode: Variable = {
     kind: "Variable",
@@ -1205,6 +1208,7 @@ function buildVariable(property: ObjProperty): Variable {
     static: property.static === true,
     type: buildType(property.type),
     visibility: property.visibility,
+    readonly: property.readonly === true,
     optional: property.optional === true,
   };
 

--- a/packages/dts-generator/src/types/api-json.d.ts
+++ b/packages/dts-generator/src/types/api-json.d.ts
@@ -257,6 +257,7 @@ export interface ObjProperty {
   export?: string;
   resource?: string;
   visibility?: "public" | "protected" | "private" | "restricted";
+  readonly?: boolean;
   static?: boolean;
   type: string;
   description?: string;

--- a/packages/dts-generator/src/types/ast.d.ts
+++ b/packages/dts-generator/src/types/ast.d.ts
@@ -129,6 +129,7 @@ export interface Variable extends AstNode, UI5JSDocs {
   static?: boolean;
   type: Type;
   visibility: UI5Visibility;
+  readonly?: boolean;
   optional: boolean;
 }
 


### PR DESCRIPTION
"esmOnly" can be used as property of entire overlays as well as of single methods and properties.
An ObjectProperty in api.json or an overlay for it can now be "readonly".