### PR TITLE
feat(ts-interface-generator): support ts path mappings with configDir template variable

### DIFF
--- a/packages/ts-interface-generator/src/addSourceExports.ts
+++ b/packages/ts-interface-generator/src/addSourceExports.ts
@@ -36,7 +36,7 @@ function addSourceExports(
   const filePath = path.normalize(fileName); // e.g. 'c:\SAPDevelop\git\ui5-typescript-control-library\src-ts\com\myorg\myUI5Library\Example.ts
   let globalName: string, moduleFileName: string;
   for (let i = 0; i < allPathMappings.length; i++) {
-    const fullTargetPath = path.join(basePath, allPathMappings[i].target);
+    const fullTargetPath = path.resolve(basePath, allPathMappings[i].target);
     if (filePath.indexOf(fullTargetPath) === 0) {
       const restPath = filePath.replace(fullTargetPath, "");
       moduleFileName = path

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyControl.gen.d.ts
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyControl.gen.d.ts
@@ -1,0 +1,81 @@
+import { MyJSEnum } from "my/library";
+import { MyTSEnum } from "my/library";
+import MyDependency from "my/MyDependency";
+import { PropertyBindingInfo } from "sap/ui/base/ManagedObject";
+import { $ControlSettings } from "sap/ui/core/Control";
+
+declare module "./MyControl" {
+
+    /**
+     * Interface defining the settings object used in constructor calls
+     */
+    interface $MyControlSettings extends $ControlSettings {
+        myJSEnumVal?: MyJSEnum | PropertyBindingInfo | `{${string}}`;
+        myTSEnumVal?: MyTSEnum | PropertyBindingInfo | `{${string}}`;
+        myDependency?: MyDependency | PropertyBindingInfo | `{${string}}`;
+    }
+
+    export default interface MyControl {
+
+        // property: myJSEnumVal
+
+        /**
+         * Gets current value of property "myJSEnumVal".
+         *
+         * Default value is: "MyJSEnum.Foo,"
+         * @returns Value of property "myJSEnumVal"
+         */
+        getMyJSEnumVal(): MyJSEnum;
+
+        /**
+         * Sets a new value for property "myJSEnumVal".
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * Default value is: "MyJSEnum.Foo,"
+         * @param [myJSEnumVal="MyJSEnum.Foo,"] New value for property "myJSEnumVal"
+         * @returns Reference to "this" in order to allow method chaining
+         */
+        setMyJSEnumVal(myJSEnumVal: MyJSEnum): this;
+
+        // property: myTSEnumVal
+
+        /**
+         * Gets current value of property "myTSEnumVal".
+         *
+         * Default value is: "MyTSEnum.Foo,"
+         * @returns Value of property "myTSEnumVal"
+         */
+        getMyTSEnumVal(): MyTSEnum;
+
+        /**
+         * Sets a new value for property "myTSEnumVal".
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * Default value is: "MyTSEnum.Foo,"
+         * @param [myTSEnumVal="MyTSEnum.Foo,"] New value for property "myTSEnumVal"
+         * @returns Reference to "this" in order to allow method chaining
+         */
+        setMyTSEnumVal(myTSEnumVal: MyTSEnum): this;
+
+        // property: myDependency
+
+        /**
+         * Gets current value of property "myDependency".
+         *
+         * @returns Value of property "myDependency"
+         */
+        getMyDependency(): MyDependency;
+
+        /**
+         * Sets a new value for property "myDependency".
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * @param myDependency New value for property "myDependency"
+         * @returns Reference to "this" in order to allow method chaining
+         */
+        setMyDependency(myDependency: MyDependency): this;
+    }
+}

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyControl.ts
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyControl.ts
@@ -1,0 +1,24 @@
+import Control from "sap/ui/core/Control";
+import type { MetadataOptions } from "sap/ui/core/Element";
+import { MyJSEnum, MyTSEnum } from "./library";
+
+export default class MyControl extends Control {
+    static readonly metadata: MetadataOptions = {
+        properties: {
+            myJSEnumVal: {
+                type: "my.MyJSEnum",
+                defaultValue: MyJSEnum.Foo,
+            },
+            myTSEnumVal: {
+                type: "my.MyTSEnum",
+                defaultValue: MyTSEnum.Foo,
+            },
+            myDependency: {
+                type: "my.MyDependency",
+            },
+        },
+    };
+    constructor(idOrSettings?: string | $MyControlSettings);
+    constructor(id?: string, settings?: $MyControlSettings);
+    constructor(id?: string, settings?: $MyControlSettings) { super(id, settings); }
+}

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyDependency.gen.d.ts
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyDependency.gen.d.ts
@@ -1,0 +1,36 @@
+import { PropertyBindingInfo } from "sap/ui/base/ManagedObject";
+import { $ControlSettings } from "sap/ui/core/Control";
+
+declare module "./MyDependency" {
+
+    /**
+     * Interface defining the settings object used in constructor calls
+     */
+    interface $MyDependencySettings extends $ControlSettings {
+        foo?: string | PropertyBindingInfo;
+    }
+
+    export default interface MyDependency {
+
+        // property: foo
+
+        /**
+         * Gets current value of property "foo".
+         *
+         * Default value is: "bar"
+         * @returns Value of property "foo"
+         */
+        getFoo(): string;
+
+        /**
+         * Sets a new value for property "foo".
+         *
+         * When called with a value of "null" or "undefined", the default value of the property will be restored.
+         *
+         * Default value is: "bar"
+         * @param [foo="bar"] New value for property "foo"
+         * @returns Reference to "this" in order to allow method chaining
+         */
+        setFoo(foo: string): this;
+    }
+}

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyDependency.ts
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/MyDependency.ts
@@ -1,0 +1,17 @@
+import Control from "sap/ui/core/Control";
+import type { MetadataOptions } from "sap/ui/core/Element";
+
+export default class MyDependency extends Control {
+    static readonly metadata: MetadataOptions = {
+        properties: {
+            foo: {
+                type: "string",
+                defaultValue: "bar",
+            },
+        },
+    };
+
+    constructor(idOrSettings?: string | $MyDependencySettings);
+    constructor(id?: string, settings?: $MyDependencySettings);
+    constructor(id?: string, settings?: $MyDependencySettings) { super(id, settings); }
+}

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/library.ts
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/library.ts
@@ -1,0 +1,29 @@
+import DataType from "sap/ui/base/DataType";
+import Lib from "sap/ui/core/Lib";
+
+const thisLib: object&{MyJSEnum?: object; MyTSEnum?: object} = Lib.init({
+    name: "my",
+    version: "${version}",
+    dependencies: ["sap.ui.core"],
+    types: [],
+    interfaces: [],
+    controls: [],
+    elements: [],
+    noLibraryCSS: false,
+});
+
+export const MyJSEnum = {
+    Foo: "foo",
+    Bar: "bar",
+} as const;
+thisLib.MyJSEnum = MyJSEnum;
+DataType.registerEnum("mylib.MyJSEnum", thisLib.MyJSEnum);
+
+export enum MyTSEnum {
+    Foo = "foo",
+    Bar = "bar",
+}
+thisLib.MyTSEnum = MyTSEnum;
+DataType.registerEnum("mylib.MyTSEnum", thisLib.MyTSEnum);
+
+export default thisLib;

--- a/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/tsconfig.json
+++ b/packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "Node16",
+        "strict": true,
+        "moduleResolution": "Node16",
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "paths": {
+            "my/*": ["${configDir}/*"]
+        }
+    }
+}


### PR DESCRIPTION
fix #484

- [generateTSInterfacesAPI.ts](packages/ts-interface-generator/src/generateTSInterfacesAPI.ts)
  - Reusable determination of local exports for usage in tests.
- [testcaseRunner.test.ts](packages/ts-interface-generator/src/test/testcases/testcaseRunner.test.ts)
  - Support test cases with custom `tsconfig.json`.
  - Support testing interface generation with local exports. (mimicing behaviour of [generateTSInterfacesAPI.ts](packages/ts-interface-generator/src/generateTSInterfacesAPI.ts))
- [testcases/tsconfig-path-relative/](packages/ts-interface-generator/src/test/testcases/tsconfig-path-relative/)
  - Added testcase for interface generation with local exports.
- [addSourceExports.ts](packages/ts-interface-generator/src/addSourceExports.ts)
  - Support ts path mappings that use `${configDir}` template variable.