### PR TITLE
fix(dts-generator): detect broken method names and throw error

### DIFF
--- a/packages/dts-generator/docs/TECHNICAL.md
+++ b/packages/dts-generator/docs/TECHNICAL.md
@@ -44,6 +44,7 @@ The generator works in several phases, which are reflected as modules in [`src/p
 Using `directives` as input and the information whether modules or globals should be generated, this phase does plenty of adjustments in the original api.json files:
 
 - `mergeOverlays` merges in the overlays from directives
+- `validateNames` does some rudimentary sanity checks for real-world issues which are otherwise hard to debug
 - `substituteSapClassInfoTypedef` adds the sap.ClassInfo typedef
 - `convertCoreAndConfigurationIntoANamespace` converts `sap.ui.core.Core` and `sap.ui.core.Configuration` from a class (needed as such in the SDK) into a namespace because the module export of both is an _instance_, not the class
 - `moveTypeParametersFromConstructorToClass` moves any type parameters from a class's constructor to the class itself. It is more common to build a generic class than building a constructor that has a generic parameter. Newer versions of UI5 (starting with 1.113) will already export the api.json like that, the code in `moveTypeParametersFromConstructorToClass` can handle this.


### PR DESCRIPTION
Writing a method name like

MyModule[SomeEnum.EnumValue] = async function (param) {

in the UI5 source code led to a method name "undefined]" in api.json, which led to a broken dts file and all kinds of unrelated tsc errors. While it should have been detected earlier, it does not hurt to check some names here.