### PR TITLE
fix(dts-generator): handle enum values properly which are quoted strings

### DIFF
--- a/packages/dts-generator/src/phases/dts-code-gen.ts
+++ b/packages/dts-generator/src/phases/dts-code-gen.ts
@@ -742,7 +742,11 @@ function genEnumValue(ast: Variable, withValue = false) {
   let text = "";
   text += JSDOC(ast) + NL;
   if (withValue) {
-    text += `${ast.name} = "${(ast as VariableWithValue).value}",`; // TODO string escaping
+    let astVal = (ast as VariableWithValue).value;
+    if (typeof astVal !== "string" || !astVal.match(/^".*"$/)) {
+      astVal = `"${astVal}"`; // TODO string escaping
+    }
+    text += `${ast.name} = ${astVal},`;
   } else {
     text += `${ast.name},`;
   }


### PR DESCRIPTION
Happens when name===value and name contains special characters