### PR TITLE
fix(dts-generator): support rest parameters in functions in nested types

### DIFF
--- a/packages/dts-generator/src/phases/dts-code-gen.ts
+++ b/packages/dts-generator/src/phases/dts-code-gen.ts
@@ -883,7 +883,7 @@ function genType(ast: Type, usage: string = "unknown"): string {
         if (!_.isEmpty(ast.typeParameters)) {
           text += `<${_.map(ast.typeParameters, (param) => param.name).join(", ")}>`; // TODO defaults, constraints, expressions
         }
-        text += `(${_.map(ast.parameters, (param) => `${param.type?.repeatable ? "..." : ""}${param.name}${param.optional ? "?" : ""}: ${genType(param.type, "parameter")}`).join(", ")})`;
+        text += `(${_.map(ast.parameters, (param) => `${param.repeatable ? "..." : ""}${param.name}${param.optional ? "?" : ""}: ${genType(param.type, "parameter")}`).join(", ")})`;
         text += ` => ${ast.type ? genType(ast.type, "returnValue") : "void"}`;
       }
       return text;

--- a/packages/dts-generator/src/phases/dts-code-gen.ts
+++ b/packages/dts-generator/src/phases/dts-code-gen.ts
@@ -867,14 +867,25 @@ function genType(ast: Type, usage: string = "unknown"): string {
       return intersectionTypes.join(" & ");
     case "FunctionType":
       text = "";
-      if (ast.isConstructor) {
-        text += "new ";
+      if (
+        !ast.isConstructor &&
+        _.isEmpty(ast.typeParameters) &&
+        _.isEmpty(ast.parameters) &&
+        !ast.type
+      ) {
+        // for simple functions, generate "Function" type
+        text += "Function";
+      } else {
+        // generate arrow function type
+        if (ast.isConstructor) {
+          text += "new ";
+        }
+        if (!_.isEmpty(ast.typeParameters)) {
+          text += `<${_.map(ast.typeParameters, (param) => param.name).join(", ")}>`; // TODO defaults, constraints, expressions
+        }
+        text += `(${_.map(ast.parameters, (param) => `${param.type?.repeatable ? "..." : ""}${param.name}${param.optional ? "?" : ""}: ${genType(param.type, "parameter")}`).join(", ")})`;
+        text += ` => ${ast.type ? genType(ast.type, "returnValue") : "void"}`;
       }
-      if (!_.isEmpty(ast.typeParameters)) {
-        text += `<${_.map(ast.typeParameters, (param) => param.name).join(", ")}>`; // TODO defaults, constraints, expressions
-      }
-      text += `(${_.map(ast.parameters, (param) => `${param.name}${param.optional ? "?" : ""}: ${genType(param.type, "parameter")}`).join(", ")})`;
-      text += ` => ${ast.type ? genType(ast.type, "returnValue") : "void"}`;
       return text;
     case "NativeTSTypeExpression":
       // native TS type expression, emit the 'type' string "as is"

--- a/packages/dts-generator/src/types/ast.d.ts
+++ b/packages/dts-generator/src/types/ast.d.ts
@@ -196,7 +196,7 @@ export interface ExperimentalDesc extends Description {
 
 // Types
 
-export type Type =
+export type Type = (
   | TypeReference
   | TypeLiteral
   | UnionType
@@ -204,7 +204,8 @@ export type Type =
   | ArrayType
   | FunctionType
   | LiteralType
-  | NativeTSTypeExpression;
+  | NativeTSTypeExpression
+) & { repeatable?: boolean };
 
 export interface TypeReference {
   kind: "TypeReference";

--- a/packages/dts-generator/src/types/ast.d.ts
+++ b/packages/dts-generator/src/types/ast.d.ts
@@ -196,7 +196,7 @@ export interface ExperimentalDesc extends Description {
 
 // Types
 
-export type Type = (
+export type Type =
   | TypeReference
   | TypeLiteral
   | UnionType
@@ -204,8 +204,7 @@ export type Type = (
   | ArrayType
   | FunctionType
   | LiteralType
-  | NativeTSTypeExpression
-) & { repeatable?: boolean };
+  | NativeTSTypeExpression;
 
 export interface TypeReference {
   kind: "TypeReference";

--- a/packages/dts-generator/src/utils/ts-ast-type-builder.ts
+++ b/packages/dts-generator/src/utils/ts-ast-type-builder.ts
@@ -115,6 +115,7 @@ export class TSASTTypeBuilder {
       name: "p" + (idx + 1), // JSDoc function types don't allow parameter names -> generate names
       type: param,
       optional: (param as any).optional,
+      repeatable: (param as any).repeatable,
     }));
     if (thisType != null) {
       // for TS, a 'this' type is specified as the first parameter type of a function

--- a/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
+++ b/test-packages/openui5-snapshot-test/output-dts/sap.ui.core.d.ts
@@ -83938,11 +83938,11 @@ declare module "sap/ui/test/Opa5" {
      * whether a function is used as arrangement or action. Each function typically contains one or multiple
      * `waitFor` statements.
      */
-    actions?: Record<string, () => void> | Function;
+    actions?: Record<string, Function> | Function;
     /**
      * A map or a class of functions that can be used as assertions in Opa tests.
      */
-    assertions?: Record<string, () => void> | Function;
+    assertions?: Record<string, Function> | Function;
   };
 }
 


### PR DESCRIPTION
When api.json contains:
Object<string,function(...any)>|function

Then the d.ts file will contain:
Record<string, (...p1: any) => void> | Function;

Before this fix, the function had no parameter.